### PR TITLE
开放 LoggerBuilder 继承能力，允许业务端在构建过程中添加自己的属性

### DIFF
--- a/src/DotNetCampus.Logger/LoggerBuilder.cs
+++ b/src/DotNetCampus.Logger/LoggerBuilder.cs
@@ -8,7 +8,7 @@ namespace DotNetCampus.Logging;
 /// <summary>
 /// 辅助创建日志记录器的构建器。
 /// </summary>
-public sealed class LoggerBuilder
+public class LoggerBuilder
 {
     private LogOptions? _options;
     private readonly List<ILogger> _writers = [];
@@ -54,7 +54,7 @@ public sealed class LoggerBuilder
         return this;
     }
 
-    public LoggerBuilder<CompositeLogger> Build()
+    public virtual LoggerBuilder<CompositeLogger> Build()
     {
         var logger = new CompositeLogger(_options ?? new LogOptions())
         {


### PR DESCRIPTION
如自己实现自己风格的多实例。如果没有开放会如何？业务方无法获取 Build 时机，只好在 Add 之前执行配置